### PR TITLE
Added scala.options for extra options in scala command line

### DIFF
--- a/R/rscala/R/scala.R
+++ b/R/rscala/R/scala.R
@@ -29,6 +29,8 @@
 #'   The value here supersedes that from \code{\link{scalaMemory}}. Without this
 #'   being set in either \code{\link{scala}} or \code{\link{scalaMemory}}, the
 #'   heap maximum will be 90\% of the available RAM.
+#' @param scala.options Extra options to be passed to scala interpreter.
+#'   It is expected to be a character vector, one value per option.
 #' @param debug (Developer use only.)  Logical indicating whether debugging
 #'   should be enabled.
 #'

--- a/R/rscala/R/scala.R
+++ b/R/rscala/R/scala.R
@@ -29,8 +29,9 @@
 #'   The value here supersedes that from \code{\link{scalaMemory}}. Without this
 #'   being set in either \code{\link{scala}} or \code{\link{scalaMemory}}, the
 #'   heap maximum will be 90\% of the available RAM.
-#' @param scala.options Extra options to be passed to scala interpreter.
-#'   It is expected to be a character vector, one value per option.
+#' @param command.line.arguments A character vector of extra command line
+#'   arguments to pass to the Scala executable, where each element corresponds
+#'   to one argument.
 #' @param debug (Developer use only.)  Logical indicating whether debugging
 #'   should be enabled.
 #'
@@ -59,7 +60,7 @@ scala <- function(JARs=character(),
                   stderr=TRUE,
                   port=0L,
                   heap.maximum=NULL,
-                  scala.options=NULL,
+                  command.line.arguments=character(0),
                   debug=FALSE) {
   if ( identical(stdout,TRUE) ) stdout <- ""
   if ( identical(stderr,TRUE) ) stderr <- ""
@@ -77,12 +78,12 @@ scala <- function(JARs=character(),
       sConfig$error <- list(message=paste0("\n\n<<<<<<<<<<\n<<<<<<<<<<\n<<<<<<<<<<\n\nScala version ",sConfig$scalaFullVersion," is not among the support versions: ",paste(names(scalaVersionJARs()),collapse=", "),".\nPlease run 'rscala::scalaConfig(reconfig=TRUE)'\n\n>>>>>>>>>>\n>>>>>>>>>>\n>>>>>>>>>>\n"))
     } else {
       heap.maximum <- getHeapMaximum(heap.maximum,sConfig$javaArchitecture == 32)
-      command.line.options <- if ( is.null(heap.maximum) ) NULL
+      heap.maximum.argument <- if ( is.null(heap.maximum) ) NULL
       else shQuote(paste0("-J-Xmx",heap.maximum))
       sessionFilename <- tempfile("rscala-session-")
       writeLines(character(),sessionFilename)
       portsFilename <- tempfile("rscala-ports-")
-      args <- c(command.line.options,shQuote(scala.options),"-nc","-classpath",rscalaJAR,"org.ddahl.rscala.server.Main",rscalaJAR,port,portsFilename,sessionFilename,debug,serialize.output,FALSE)
+      args <- c(heap.maximum.argument,shQuote(command.line.arguments),"-nc","-classpath",rscalaJAR,"org.ddahl.rscala.server.Main",rscalaJAR,port,portsFilename,sessionFilename,debug,serialize.output,FALSE)
       oldJavaEnv <- setJavaEnv(sConfig)
       system2(sConfig$scalaCmd,args,wait=FALSE,stdout=stdout,stderr=stderr)
       setJavaEnv(oldJavaEnv)

--- a/R/rscala/R/scala.R
+++ b/R/rscala/R/scala.R
@@ -50,13 +50,14 @@
 #' s(mean=h, sd=2, r=rng) * 'mean + sd * r.nextGaussian()'
 #' close(s)
 #' }
-#' 
+#'
 scala <- function(JARs=character(),
                   serialize.output=.Platform$OS.type=="windows",
                   stdout=TRUE,
                   stderr=TRUE,
                   port=0L,
                   heap.maximum=NULL,
+                  scala.options=NULL,
                   debug=FALSE) {
   if ( identical(stdout,TRUE) ) stdout <- ""
   if ( identical(stderr,TRUE) ) stderr <- ""
@@ -79,8 +80,8 @@ scala <- function(JARs=character(),
       sessionFilename <- tempfile("rscala-session-")
       writeLines(character(),sessionFilename)
       portsFilename <- tempfile("rscala-ports-")
-      args <- c(command.line.options,"-nc","-classpath",rscalaJAR,"org.ddahl.rscala.server.Main",rscalaJAR,port,portsFilename,sessionFilename,debug,serialize.output,FALSE)
-      oldJavaEnv <- setJavaEnv(sConfig) 
+      args <- c(command.line.options,shQuote(scala.options),"-nc","-classpath",rscalaJAR,"org.ddahl.rscala.server.Main",rscalaJAR,port,portsFilename,sessionFilename,debug,serialize.output,FALSE)
+      oldJavaEnv <- setJavaEnv(sConfig)
       system2(sConfig$scalaCmd,args,wait=FALSE,stdout=stdout,stderr=stderr)
       setJavaEnv(oldJavaEnv)
       assign("sessionFilename",sessionFilename,envir=details)
@@ -88,7 +89,7 @@ scala <- function(JARs=character(),
     }
   }
   assign("closed",FALSE,envir=details)
-  assign("disconnected",TRUE,envir=details) 
+  assign("disconnected",TRUE,envir=details)
   assign("pidOfR",Sys.getpid(),envir=details)
   assign("interrupted",FALSE,envir=details)
   transcompileHeader <- c("import org.ddahl.rscala.server.Transcompile._","import scala.util.control.Breaks")
@@ -144,7 +145,7 @@ mkBridge <- function(details) {
     bridge2
   }
   attr(bridge,"details") <- details
-  class(bridge) <- "rscalaBridge"    
+  class(bridge) <- "rscalaBridge"
   bridge
 }
 
@@ -154,7 +155,7 @@ embeddedR <- function(ports,debug=FALSE) {
   assign("serializeOutput",FALSE,envir=details)
   assign("debug",debug,envir=details)
   assign("socketInPort",ports[1],envir=details)
-  assign("socketOutPort",ports[2],envir=details) 
+  assign("socketOutPort",ports[2],envir=details)
   assign("pendingJARs",character(0),envir=details)
   assign("pendingCallbacks",character(0),envir=details)
   scalaConnect(details)
@@ -178,8 +179,8 @@ scalaConnect <- function(details) {
     unlink(portsFilename)
     rm("portsFilename",envir=details)
     assign("socketInPort",ports[1],envir=details)
-    assign("socketOutPort",ports[2],envir=details) 
-    assign("pidOfScala",ports[3],envir=details) 
+    assign("socketOutPort",ports[2],envir=details)
+    assign("pidOfScala",ports[3],envir=details)
   }
   socketIn  <- socketConnection(host="localhost", port=details[['socketInPort']],  server=FALSE, blocking=TRUE, open="rb", timeout=2678400L)
   socketOut <- socketConnection(host="localhost", port=details[['socketOutPort']], server=FALSE, blocking=TRUE, open="ab", timeout=2678400L)


### PR DESCRIPTION
With this pull request, it is enabled a way to set extra command line arguments to scala. I needed this feature to include the option "-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005" to allow remote-debugging on the scala code.

This option can be useful to set any other command line parameter when launching scala server.