### PR TITLE
update dependency versions for binary compatibility with scala-glm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,15 @@ organization := "org.ddahl"
 //version := "3.2.20"
 version := "3.2.19-SNAPSHOT"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.10"
 
 crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1")
 
 scalacOptions ++= List("-feature", "-deprecation", "-unchecked")
 
-sources in (Compile, doc) ~= (_ filter (_.getName endsWith ".scala"))
+Compile / doc / sources ~= (_ filter (_.getName endsWith ".scala"))
 
-scalacOptions in (Compile,doc) ++= Seq("-no-link-warnings", "-skip-packages", "scala:org.ddahl.rscala.server")
+Compile / doc/ scalacOptions ++= Seq("-no-link-warnings", "-skip-packages", "scala:org.ddahl.rscala.server")
 
 libraryDependencies ++= List(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.9
+sbt.version = 1.8.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+scalaVersion := "2.12.17"
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15") // "3.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")         // "2.0.0")

--- a/src/main/scala/org/ddahl/rscala/RClient.scala
+++ b/src/main/scala/org/ddahl/rscala/RClient.scala
@@ -82,7 +82,7 @@ class RClient private[rscala] () {
   def evalObject(template: String, values: Any*): RObject = synchronized {
     val template2 = "I(serialize({" + template + "},NULL))"
     evalEngine(template2, values)
-    val x = server.conduit.pop[Array[Byte]]
+    val x = server.conduit.pop[Array[Byte]]()
     new RObject(x)
   }
 
@@ -93,7 +93,7 @@ class RClient private[rscala] () {
 
   private def evalWithResult[A](template: String, values: Seq[Any], casting: String): A = synchronized {
     evalEngine(".rs <- {" + template + "}; " + casting, values)
-    server.conduit.pop[A]
+    server.conduit.pop[A]()
   }
 
   private def evalEngine(template: String, values: Seq[Any]): Unit = synchronized {
@@ -217,9 +217,9 @@ object RClient {
   }
 
   private lazy val allCodeInR = {
-    val scripts = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/Rscripts")).getLines
+    val scripts = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/Rscripts")).getLines()
     val codeInR = scripts.map(resource => {
-      scala.io.Source.fromInputStream(getClass.getResourceAsStream(resource)).getLines.mkString("\n")
+      scala.io.Source.fromInputStream(getClass.getResourceAsStream(resource)).getLines().mkString("\n")
     }).mkString("\n\n")
     s"""
     rscala <- local({

--- a/src/main/scala/org/ddahl/rscala/server/Debugger.scala
+++ b/src/main/scala/org/ddahl/rscala/server/Debugger.scala
@@ -8,7 +8,7 @@ class Debugger(var on: Boolean, out: java.io.PrintWriter, val label: String, val
 
   def apply(msg: String): Unit = {
     if ( on ) {
-      val pretext = "DEBUG (" + label + ") " + (if (withTime) timestamp else "") + ": "
+      val pretext = "DEBUG (" + label + ") " + (if (withTime) timestamp() else "") + ": "
       if (msg.length > maxOutputLength) out.println(pretext + msg.substring(0, maxOutputLength - 3) + "...")
       else out.println(pretext + msg)
       out.flush()

--- a/src/main/scala/org/ddahl/rscala/server/Transcompile.scala
+++ b/src/main/scala/org/ddahl/rscala/server/Transcompile.scala
@@ -314,7 +314,7 @@ object Transcompile extends TranscompileStub {
   def _floor(x: Double): Double = math.floor(x)
   def _floor(x: Array[Double]): Array[Double] = x map { math.floor }
 
-  def _round(x: Double): Double = math.round(x)
+  def _round(x: Double): Double = math.round(x).toDouble
   def _round(x: Array[Double]): Array[Double] = x map { z => math.round(z).toDouble }
 
   def _random(): Double = scala.util.Random.nextDouble()


### PR DESCRIPTION
The excellent library [scala-glm](https://github.com/darrenjw/scala-glm/issues) has been incompatible with recent versions of the scala 3 version of [scalanlp.breeze](https://github.com/scalanlp/breeze), due to `scala-glm` specifying older versions of several libraries.    The effort to update `scala-glm` dependencies transitively led to this PR.

This PR updates the following library version strings:
```diff
diff --git a/build.sbt b/build.sbt
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.10"

-sources in (Compile, doc) ~= (_ filter (_.getName endsWith ".scala"))
+Compile / doc / sources ~= (_ filter (_.getName endsWith ".scala"))

-scalacOptions in (Compile,doc) ++= Seq("-no-link-warnings", "-skip-packages", "scala:org.ddahl.rscala.server")
+Compile / doc/ scalacOptions ++= Seq("-no-link-warnings", "-skip-packages", "scala:org.ddahl.rscala.server")

diff --git a/project/build.properties b/project/build.properties
-sbt.version = 1.3.9
+sbt.version = 1.8.0

diff --git a/project/plugins.sbt b/project/plugins.sbt
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+scalaVersion := "2.12.17"
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15") // "3.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")         // "2.0.0")
```
Updating the `sbt` version produced two deprecation warnings in `build.sbt`, and the recommended updates were applied.

Updating of library version strings produced a few trivial build warnings, all fixed.

<details>
<pre>
[info] compiling 11 Scala sources to C:\Users\philwalk\workspace\rscala\target\scala-2.13\classes ...
[warn] C:\Users\philwalk\workspace\rscala\src\main\scala\org\ddahl\rscala\RClient.scala:85:31: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method pop,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     val x = server.conduit.pop[Array[Byte]]
[warn]                               ^
[warn] C:\Users\philwalk\workspace\rscala\src\main\scala\org\ddahl\rscala\RClient.scala:96:23: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method pop,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     server.conduit.pop[A]
[warn]                       ^
[warn] C:\Users\philwalk\workspace\rscala\src\main\scala\org\ddahl\rscala\RClient.scala:220:94: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method getLines,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     val scripts = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/Rscripts")).getLines
[warn]                                                                                              ^
[warn] C:\Users\philwalk\workspace\rscala\src\main\scala\org\ddahl\rscala\RClient.scala:222:79: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method getLines,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]       scala.io.Source.fromInputStream(getClass.getResourceAsStream(resource)).getLines.mkString("\n")
[warn]                                                                               ^
[warn] C:\Users\philwalk\workspace\rscala\src\main\scala\org\ddahl\rscala\server\Debugger.scala:11:63: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method timestamp,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]       val pretext = "DEBUG (" + label + ") " + (if (withTime) timestamp else "") + ": "
[warn]                                                               ^
[warn] C:\Users\philwalk\workspace\rscala\src\main\scala\org\ddahl\rscala\server\Transcompile.scala:317:45: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
[warn]   def _round(x: Double): Double = math.round(x)
</pre>
</details>

Binary compatibility was verified against locally published versions of this and of an updated `scala-glm`. 

The related `scala-glm` PR is [scala-glm #3](https://github.com/darrenjw/scala-glm/pull/3)
